### PR TITLE
Link Sanitization

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,4 +2,14 @@ class Project < ApplicationRecord
   has_one_attached :ProjectCover
   validates :TypeID, presence: true
   has_one :Contribution, through: :DisplayLine
+
+  # From https://stackoverflow.com/questions/36038646/string-interpolation-to-external-link-without-http
+  # For Input Sanitization
+  def ProjectLink=(url)
+    if url.present?
+      url = url.match(/https?:\/\//) ? url : "http://#{url}"
+      write_attribute(:ProjectLink, url)
+    end
+  end
+  
 end

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -21,7 +21,7 @@
     <% @projects.each do |project| %>
       <tr>
         <td><%= project.ProjectName %></td>
-        <td><%= project.ProjectLink %></td>
+        <td><%= link_to "Link", project.ProjectLink, rel: 'noopener', target: '_blank' %> </td>
         <td><%= project.ProjectOwner %></td>
         <td><%= project.ProjectStart %></td>
         <td><%= project.ProjectEnd %></td>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -7,7 +7,7 @@
 
 <p>
   <strong>Project Link:</strong>
-  <%= link_to "Link", @project.ProjectLink %>
+  <%= link_to "Link", @project.ProjectLink, rel: 'noopener', target: '_blank' %> 
 </p>
 
 <p>


### PR DESCRIPTION
Added some link sanitization to the project creation page. This fixes the problem of RoR trying to use the user-provided links that do not contain "http" as a route (appends link to current url).