### PR TITLE
Referential Integrity Fix

### DIFF
--- a/app/controllers/awards_controller.rb
+++ b/app/controllers/awards_controller.rb
@@ -49,6 +49,10 @@ class AwardsController < ApplicationController
   def destroy
     @award.destroy
 
+    Awarded.where(AwardID: @award.id).find_each do |aw|
+      aw.destroy
+    end
+
     respond_to do |format|
       format.html { redirect_to(awards_url, notice: 'Award was successfully destroyed.') }
       format.json { head(:no_content) }

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -49,7 +49,7 @@ class ContributionsController < ApplicationController
   def destroy
     @contribution.destroy
 
-    DisplayLine.where(Project: @contribution.id).find_each do |dl|
+    DisplayLine.where(Contribution: @contribution.id).find_each do |dl|
       dl.destroy
     end
 


### PR DESCRIPTION
Fixed issue that would break the app when a contribution or award was deleted without first removing the display line or awardeds first.